### PR TITLE
fix(jsii-release-shim): command line arguments dropped

### DIFF
--- a/bin/jsii-release-shim
+++ b/bin/jsii-release-shim
@@ -16,4 +16,4 @@ if [ ! -e "${actual}" ]; then
   exit 1
 fi
 
-exec "${actual}"
+exec "${actual}" "$@"


### PR DESCRIPTION
When executing publib through the `jsii-release` shim, the command line arguments are dropped.

When executed as follows:

```
jsii-release jsii-release-golang go/
```

It drops the `"go/"` argument, and proceeds to look at the default directory `dist/go` (which then causes an error).

Fixes #