### PR TITLE
fix(pypi): Include verbose flag for twine upload

### DIFF
--- a/bin/publib-pypi
+++ b/bin/publib-pypi
@@ -32,4 +32,4 @@ if [ -z "$(ls *.whl)" ]; then
 fi
 
 python3 -m pip install --user --upgrade twine
-python3 -m twine upload --skip-existing *
+python3 -m twine upload --verbose --skip-existing *


### PR DESCRIPTION
Fixes #427 
