### PR TITLE
feat: Support cloning using SSH key

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Repository tags will be in the following format:
 |Option|Required|Description|
 |------|--------|-----------|
 |`GITHUB_TOKEN`|Required if `GITHUB_USE_SSH` is not specified|[GitHub personal access token.](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)|
-|`GITHUB_USE_SSH`|Required if `GITHUB_TOKEN` is not specified|Set any value to use SSH instead of GitHub personal access token.|
+|`GITHUB_USE_SSH`|Required if `GITHUB_TOKEN` is not specified|Set any value to use SSH with [deploy keys](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) or your private SSH key. Your system must ready to use the key as publib will not set it up.|
 |`VERSION`|Optional|Module version. Defaults to the value in the 'version' file of the module directory. Fails if it doesn't exist.|
 |`GIT_BRANCH`|Optional|Branch to push to. Defaults to 'main'.|
 |`GIT_USER_NAME`|Optional|Username to perform the commit with. Defaults to the git user.name config in the current directory. Fails if it doesn't exist.|

--- a/README.md
+++ b/README.md
@@ -220,14 +220,15 @@ Repository tags will be in the following format:
 
 |Option|Required|Description|
 |------|--------|-----------|
-|`GITHUB_TOKEN`|Required|[GitHub personal access token.](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)|
+|`GITHUB_TOKEN`|Required if `GITHUB_USE_SSH` not specified|[GitHub personal access token.](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)|
+|`GITHUB_USE_SSH`|Required if `GITHUB_TOKEN` not specified|Set any value to use SSH instead of GitHub personal access token.|
 |`VERSION`|Optional|Module version. Defaults to the value in the 'version' file of the module directory. Fails if it doesn't exist.|
 the module name.|
 |`GIT_BRANCH`|Optional|Branch to push to. Defaults to 'main'.|
 |`GIT_USER_NAME`|Optional|Username to perform the commit with. Defaults to the git user.name config in the current directory. Fails if it doesn't exist.|
 |`GIT_USER_EMAIL`|Optional|Email to perform the commit with. Defaults to the git user.email config in the current directory. Fails if it doesn't exist.|
 |`GIT_COMMIT_MESSAGE`|Optional|The commit message. Defaults to 'chore(release): $VERSION'.|
-|`DRYRUN`|Set to "true" for a dry run.|
+|`DRYRUN`|Optional|Set to "true" for a dry run.|
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -220,10 +220,9 @@ Repository tags will be in the following format:
 
 |Option|Required|Description|
 |------|--------|-----------|
-|`GITHUB_TOKEN`|Required if `GITHUB_USE_SSH` not specified|[GitHub personal access token.](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)|
-|`GITHUB_USE_SSH`|Required if `GITHUB_TOKEN` not specified|Set any value to use SSH instead of GitHub personal access token.|
+|`GITHUB_TOKEN`|Required if `GITHUB_USE_SSH` is not specified|[GitHub personal access token.](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)|
+|`GITHUB_USE_SSH`|Required if `GITHUB_TOKEN` is not specified|Set any value to use SSH instead of GitHub personal access token.|
 |`VERSION`|Optional|Module version. Defaults to the value in the 'version' file of the module directory. Fails if it doesn't exist.|
-the module name.|
 |`GIT_BRANCH`|Optional|Branch to push to. Defaults to 'main'.|
 |`GIT_USER_NAME`|Optional|Username to perform the commit with. Defaults to the git user.name config in the current directory. Fails if it doesn't exist.|
 |`GIT_USER_EMAIL`|Optional|Email to perform the commit with. Defaults to the git user.email config in the current directory. Fails if it doesn't exist.|

--- a/src/help/git.ts
+++ b/src/help/git.ts
@@ -14,7 +14,7 @@ export function clone(repositoryUrl: string, targetDir: string) {
   } else {
     const gitHubToken = process.env.GITHUB_TOKEN;
     if (!gitHubToken) {
-      throw new Error('GITHUB_TOKEN env variable is required');
+      throw new Error('GITHUB_TOKEN env variable is required when GITHUB_USE_SSH env variable is not used');
     }
     shell.run(`git clone https://${gitHubToken}@${repositoryUrl}.git ${targetDir}`);
   }

--- a/src/help/git.ts
+++ b/src/help/git.ts
@@ -7,11 +7,17 @@ import * as shell from './shell';
  * @param targetDir the clone directory.
  */
 export function clone(repositoryUrl: string, targetDir: string) {
-  const gitHubToken = process.env.GITHUB_TOKEN;
-  if (!gitHubToken) {
-    throw new Error('GITHUB_TOKEN env variable is required');
+  const gitHubUseSsh = process.env.GITHUB_USE_SSH;
+  if (gitHubUseSsh) {
+    const sshRepositoryUrl = repositoryUrl.replace('/', ':');
+    shell.run(`git clone git@${sshRepositoryUrl}.git ${targetDir}`);
+  } else {
+    const gitHubToken = process.env.GITHUB_TOKEN;
+    if (!gitHubToken) {
+      throw new Error('GITHUB_TOKEN env variable is required');
+    }
+    shell.run(`git clone https://${gitHubToken}@${repositoryUrl}.git ${targetDir}`);
   }
-  shell.run(`git clone https://${gitHubToken}@${repositoryUrl}.git ${targetDir}`);
 }
 
 /**

--- a/test/targets/git.test.ts
+++ b/test/targets/git.test.ts
@@ -38,5 +38,5 @@ test('clone with ssh', () => {
 
 test('throw exception without token or ssh', () => {
   const t = () => git.clone('github.com/cdklabs/publib', 'target');
-  expect(t).toThrow('GITHUB_TOKEN env variable is required');
+  expect(t).toThrow('GITHUB_TOKEN env variable is required when GITHUB_USE_SSH env variable is not used');
 });

--- a/test/targets/git.test.ts
+++ b/test/targets/git.test.ts
@@ -1,5 +1,5 @@
-import * as shell from '../../src/help/shell';
 import * as git from '../../src/help/git';
+import * as shell from '../../src/help/shell';
 
 // mock shell.run
 jest.mock('../../src/help/shell');
@@ -9,7 +9,7 @@ const mockedShellRun = (shell.run as unknown) as jest.Mock<typeof shell.run>;
 const OLD_ENV = process.env;
 
 beforeEach(() => {
-  jest.resetModules() // Most important - it clears the cache
+  jest.resetModules(); // Most important - it clears the cache
   process.env = { ...OLD_ENV }; // Make a copy
 });
 
@@ -29,7 +29,7 @@ test('clone with token', () => {
 
 test('clone with ssh', () => {
   process.env.GITHUB_USE_SSH = '1';
-  
+
   git.clone('github.com/cdklabs/publib', 'target');
 
   expect(mockedShellRun.mock.calls).toHaveLength(1);

--- a/test/targets/git.test.ts
+++ b/test/targets/git.test.ts
@@ -1,0 +1,42 @@
+import * as shell from '../../src/help/shell';
+import * as git from '../../src/help/git';
+
+// mock shell.run
+jest.mock('../../src/help/shell');
+const mockedShellRun = (shell.run as unknown) as jest.Mock<typeof shell.run>;
+
+// restore env after each test
+const OLD_ENV = process.env;
+
+beforeEach(() => {
+  jest.resetModules() // Most important - it clears the cache
+  process.env = { ...OLD_ENV }; // Make a copy
+});
+
+afterAll(() => {
+  process.env = OLD_ENV; // Restore old environment
+});
+
+// test
+test('clone with token', () => {
+  process.env.GITHUB_TOKEN = 'my-token';
+
+  git.clone('github.com/cdklabs/publib', 'target');
+
+  expect(mockedShellRun.mock.calls).toHaveLength(1);
+  expect(mockedShellRun.mock.calls[0]).toEqual(['git clone https://my-token@github.com/cdklabs/publib.git target']);
+});
+
+test('clone with ssh', () => {
+  process.env.GITHUB_USE_SSH = '1';
+  
+  git.clone('github.com/cdklabs/publib', 'target');
+
+  expect(mockedShellRun.mock.calls).toHaveLength(1);
+  expect(mockedShellRun.mock.calls[0]).toEqual(['git clone git@github.com:cdklabs/publib.git target']);
+});
+
+test('throw exception without token or ssh', () => {
+  const t = () => git.clone('github.com/cdklabs/publib', 'target');
+  expect(t).toThrow('GITHUB_TOKEN env variable is required');
+});


### PR DESCRIPTION
Using git with a token might be simpler, but personal access tokens are very powerful. Using GitHub deploy keys will provide more fine grained control. If the secret is exposed, it will only affect that one specific repository. This will allow releasing go packages in projen without supplying a personal access token.