### PR TITLE
feat(npm): support npm publishing with access level

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npx publib-npm [DIR]
 |`NPM_TOKEN`|Optional|Registry authentication token (either [npm.js publishing token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) or a [GitHub personal access token](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages#authenticating-to-github-packages)), not used for AWS CodeArtifact|
 |`NPM_REGISTRY`|Optional|The registry URL (defaults to "registry.npmjs.org"). Use "npm.pkg.github.com" to publish to GitHub Packages. Use repository endpoint for AWS CodeAtifact, e.g. "my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/npm/my_repo/".|
 |`NPM_DIST_TAG`|Optional|Registers the published package with the given [dist-tag](https://docs.npmjs.com/cli/dist-tag) (e.g. `next`, default is `latest`)|
+|`NPM_ACCESS_LEVEL`|Optional|Publishes the package with the given [access level](https://docs.npmjs.com/cli/v8/commands/npm-publish#access) (e.g. `public`, default is `restricted` for scoped packages and `public` for unscoped packages)|
 |`AWS_ACCESS_KEY_ID`|Optional|If AWS CodeArtifact is used as registry, an AWS access key can be spedified.|
 |`AWS_SECRET_ACCESS_KEY`|Optional|Secret access key that belongs to the AWS access key.|
 |`AWS_ROLE_TO_ASSUME`|Optional|If AWS CodeArtifact is used as registry, an AWS role ARN to assume before authorizing.|

--- a/bin/publib-npm
+++ b/bin/publib-npm
@@ -57,10 +57,22 @@ if [ -n "${NPM_DIST_TAG:-}" ]; then
   echo "Publishing under the following dist-tag: ${NPM_DIST_TAG}"
 fi
 
+# access level
+access=""
+if [ -n "${NPM_ACCESS_LEVEL:-}" ]; then
+  if ! [[ "${NPM_ACCESS_LEVEL}" =~ ^(public|restricted)$ ]]; then
+    echo "Invalid package access level: ${NPM_ACCESS_LEVEL}. Valid values are: public, restricted (default is restricted for scoped packages and public for unscoped packages)"
+    exit 1
+  fi
+
+  access="--access ${NPM_ACCESS_LEVEL}"
+  echo "Publishing package with access level: ${NPM_ACCESS_LEVEL}"
+fi
+
 log=$(mktemp -d)/npmlog.txt
 
 for file in ${dir}/**.tgz; do
-  npm publish ${tag} ${file} 2>&1 | tee ${log}
+  npm publish ${tag} ${access} ${file} 2>&1 | tee ${log}
   exit_code="${PIPESTATUS[0]}"
 
   if [ ${exit_code} -ne 0 ]; then


### PR DESCRIPTION
Scoped npm packages cannot currently be published publicly because npm defaults to publishing them as [restricted](https://docs.npmjs.com/cli/v8/commands/npm-publish#access). This change gives the access level choice to the author.
