### PR TITLE
chore: only require deployment approval for 3P contributors

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -11,12 +11,29 @@ on:
       - ready_for_review
   merge_group: {}
 jobs:
+  targetenv:
+    permissions:
+      contents: read
+    outputs:
+      env_name: ${{ steps.undefined.outputs.undefined }}
+    steps:
+      - name: Print event output for debugging in case the condition is incorrect
+        run: cat $GITHUB_EVENT_PATH
+      - name: Start requiring approval
+        run: echo IntegTestCredentialsRequireApproval > .envname
+      - name: If maintainer, do not need approval
+        if: github.pull_request.author_association == 'OWNER' || github.pull_request.author_association == 'MEMBER' || github.pull_request.user.login == 'cdklabs-automation'
+        run: echo IntegTestCredentials > .envname
+      - name: Output the value
+        id: output
+        run: echo "env_name=$(cat .envname)" >> "$GITHUB_OUTPUT"
   test:
+    needs: targetenv
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    environment: IntegTestCredentials
+    environment: ${{needs.targetenv.outputs.env_name}}
     steps:
       - name: Federate into AWS
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      env_name: ${{ steps.undefined.outputs.undefined }}
+      env_name: ${{ steps.output.outputs.env_name }}
     steps:
       - name: Print event output for debugging in case the condition is incorrect
         run: cat $GITHUB_EVENT_PATH

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -65,6 +65,9 @@ test.on({
 // Because we have an 'if/else' condition that is quite annoying to encode with outputs, have a mutable variable by
 // means of a file on disk, export it as an output afterwards.
 test.addJob('targetenv', {
+  permissions: {
+    contents: 'read',
+  },
   steps: [
     {
       name: 'Print event output for debugging in case the condition is incorrect',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -93,7 +93,7 @@ test.addJob('targetenv', {
     },
   ],
   outputs: {
-    env_name: '${{ steps.output.outputs.env_name }}',
+    env_name: { stepId: 'output', outputName: 'env_name' },
   },
 });
 test.addJob('test', {


### PR DESCRIPTION
Mechanism:

We now have 2 otherwise identical environments, 'IntegTestCredentials' and 'IntegTestCredentialsRequireApproval', except one of them requires approvals to run.

A job will decide between them based on the submitter of the PR. If the submitter is a project member or our bot, we will pick the one that doesn't require approvals.

The output of this job is used as the value of the environment to use.
