### PR TITLE
chore: "skip approval" check failing for some members

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -11,7 +11,7 @@ on:
       - ready_for_review
   merge_group: {}
 jobs:
-  targetenv:
+  determine_env:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,14 +22,14 @@ jobs:
         run: cat $GITHUB_EVENT_PATH
       - name: Start requiring approval
         run: echo IntegTestCredentialsRequireApproval > .envname
-      - name: If maintainer, do not need approval
-        if: github.pull_request.author_association == 'OWNER' || github.pull_request.author_association == 'MEMBER' || github.pull_request.user.login == 'cdklabs-automation'
+      - name: If not from a fork, do not need approval
+        if: "! github.pull_request.head.repo.fork"
         run: echo IntegTestCredentials > .envname
       - name: Output the value
         id: output
         run: echo "env_name=$(cat .envname)" >> "$GITHUB_OUTPUT"
   test:
-    needs: targetenv
+    needs: determine_env
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Start requiring approval
         run: echo IntegTestCredentialsRequireApproval > .envname
       - name: If not from a fork, do not need approval
-        if: "! github.pull_request.head.repo.fork"
+        if: "!github.pull_request.head.repo.fork"
         run: echo IntegTestCredentials > .envname
       - name: Output the value
         id: output

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -81,7 +81,7 @@ test?.addJob('determine_env', {
     },
     {
       name: 'If not from a fork, do not need approval',
-      if: '! github.pull_request.head.repo.fork',
+      if: '!github.pull_request.head.repo.fork',
       run: 'echo IntegTestCredentials > .envname',
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -65,7 +65,7 @@ test?.on({
 // github.pull_request.user.login
 // Because we have an 'if/else' condition that is quite annoying to encode with outputs, have a mutable variable by
 // means of a file on disk, export it as an output afterwards.
-test?.addJob('targetenv', {
+test?.addJob('determine_env', {
   permissions: {
     contents: github.workflows.JobPermission.READ,
   },
@@ -80,12 +80,8 @@ test?.addJob('targetenv', {
       run: 'echo IntegTestCredentialsRequireApproval > .envname',
     },
     {
-      name: 'If maintainer, do not need approval',
-      if: [
-        'github.pull_request.author_association == \'OWNER\'',
-        'github.pull_request.author_association == \'MEMBER\'',
-        'github.pull_request.user.login == \'cdklabs-automation\'',
-      ].join(' || '),
+      name: 'If not from a fork, do not need approval',
+      if: '! github.pull_request.head.repo.fork',
       run: 'echo IntegTestCredentials > .envname',
     },
     {
@@ -104,7 +100,7 @@ test?.addJob('test', {
     idToken: github.workflows.JobPermission.WRITE,
   },
   runsOn: ['ubuntu-latest'],
-  needs: ['targetenv'],
+  needs: ['determine_env'],
   environment: '${{needs.targetenv.outputs.env_name}}',
   steps: [
     {


### PR DESCRIPTION
For some reason, @mrgrain is being marked as a `CONTRIBUTOR` (as opposed to a `MEMBER`) for this repository. This means he is not eligible for getting this PRs integ-tested without human approval.

@RomainMuller had the insight that we could simplify the check to saying "is the PR from a fork or not". Presumably people with write access are trusted, people who submit a forked PR are not.

Let's try it like this.
