### PR TITLE
fix(publib-ca): throttling errors are not retried

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -22,7 +22,7 @@ jobs:
         run: cat $GITHUB_EVENT_PATH
       - name: Start requiring approval
         run: echo IntegTestCredentialsRequireApproval > .envname
-      - name: If not from a fork, do not need approval
+      - name: If not forked, run automatically
         if: "!github.pull_request.head.repo.fork"
         run: echo IntegTestCredentials > .envname
       - name: Output the value

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -76,9 +76,9 @@ test?.on({
   mergeGroup: {},
 });
 
-// Select `IntegTestCredentials` or `IntegTestCredentialsRequireApproval` depending on the author of the PR
-// github.pull_request.author_association in ['OWNER', 'COLLABORATOR', 'MEMBER', 'NONE']
-// github.pull_request.user.login
+// Select `IntegTestCredentials` or `IntegTestCredentialsRequireApproval` depending on whether this is
+// a PR from a fork or not (assumption: writers can be trusted, forkers cannot).
+//
 // Because we have an 'if/else' condition that is quite annoying to encode with outputs, have a mutable variable by
 // means of a file on disk, export it as an output afterwards.
 test?.addJob('determine_env', {
@@ -96,7 +96,7 @@ test?.addJob('determine_env', {
       run: 'echo IntegTestCredentialsRequireApproval > .envname',
     },
     {
-      name: 'If not from a fork, do not need approval',
+      name: 'If not forked, run automatically',
       // In a mergeGroup event, `github.pull_request` will not be set and `!undefined` also counts
       if: '!github.pull_request.head.repo.fork',
       run: 'echo IntegTestCredentials > .envname',

--- a/src/codeartifact/codeartifact-repo.ts
+++ b/src/codeartifact/codeartifact-repo.ts
@@ -1,4 +1,4 @@
-import { AssociateExternalConnectionCommand, CodeartifactClient, CreateDomainCommand, CreateRepositoryCommand, DeleteRepositoryCommand, DescribeDomainCommand, DescribeRepositoryCommand, GetAuthorizationTokenCommand, GetRepositoryEndpointCommand, ListPackagesCommand, ListPackagesCommandInput, ListRepositoriesCommand, ListTagsForResourceCommand, PutPackageOriginConfigurationCommand, ResourceNotFoundException } from '@aws-sdk/client-codeartifact';
+import { AssociateExternalConnectionCommand, CodeartifactClient, CreateDomainCommand, CreateRepositoryCommand, DeleteRepositoryCommand, DescribeDomainCommand, DescribeRepositoryCommand, GetAuthorizationTokenCommand, GetRepositoryEndpointCommand, ListPackagesCommand, ListPackagesCommandInput, ListRepositoriesCommand, ListTagsForResourceCommand, PutPackageOriginConfigurationCommand, ResourceNotFoundException, ThrottlingException } from '@aws-sdk/client-codeartifact';
 import { AwsCredentialIdentityProvider, Command, MetadataBearer } from '@aws-sdk/types';
 import { sleep } from '../help/sleep';
 
@@ -309,9 +309,12 @@ async function retryThrottled<A>(block: () => Promise<A>) {
       return await block();
     } catch (e: any) {
       // eslint-disable-next-line no-console
-      console.debug(e.message);
-      if (e.code !== 'ThrottlingException') { throw e; }
-      if (attempts-- === 0) { throw e; }
+      console.debug(e);
+
+      if (!(e instanceof ThrottlingException) || --attempts === 0) {
+        throw e;
+      }
+
       await sleep(Math.floor(Math.random() * time));
       time *= 2;
     }


### PR DESCRIPTION
In SDKv3 they changed the error testing mechanism. It used to be `exc.code === '<error>'`, but now is `exc instanceof <error>`.

Fix that, and also update the documentation for the integ testing job.

Fixes #