### PR TITLE
chore: fix integ test workflow to avoid possible race condition

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -37,18 +37,18 @@ jobs:
     environment: ${{needs.determine_env.outputs.env_name}}
     steps:
       - name: Federate into AWS
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: publib-integ-test
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: yarn
       - name: Yarn install

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -122,7 +122,7 @@ test?.addJob('integ', {
   steps: [
     {
       name: 'Federate into AWS',
-      uses: 'aws-actions/configure-aws-credentials@v2',
+      uses: 'aws-actions/configure-aws-credentials@v4',
       with: {
         'aws-region': 'us-east-1',
         'role-to-assume': '${{ secrets.AWS_ROLE_TO_ASSUME }}',
@@ -131,16 +131,16 @@ test?.addJob('integ', {
     },
     {
       name: 'Checkout',
-      uses: 'actions/checkout@v3',
+      uses: 'actions/checkout@v4',
       with: {
-        ref: '${{ github.event.pull_request.head.ref }}',
+        ref: '${{ github.event.pull_request.head.sha }}',
         // Need this because we are running on pull_request_target
         repository: '${{ github.event.pull_request.head.repo.full_name }}',
       },
     },
     {
       name: 'Setup Node.js',
-      uses: 'actions/setup-node@v3',
+      uses: 'actions/setup-node@v4',
       with: {
         cache: 'yarn',
       },


### PR DESCRIPTION
Between approval of the integ test deployment and the GH Actions runner picking up the job, the contents of the referenced branch could change because `pull_request.head.ref` is mutable. Using `sha` instead which is immutable.

This PR also updates the action versions for this workflow.