### PR TITLE
chore: disable type checking of libs

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -90,11 +90,6 @@
       "type": "build"
     },
     {
-      "name": "lru-cache",
-      "version": "^11",
-      "type": "override"
-    },
-    {
       "name": "@aws-sdk/client-codeartifact",
       "type": "runtime"
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -32,10 +32,18 @@ const project = new cdklabs.CdklabsTypeScriptProject({
   ],
   enablePRAutoMerge: true,
   setNodeEngineVersion: false,
+  tsconfig: {
+    compilerOptions: {
+      // Conflict between `commit-and-tag-version@12` and modern TypeScript.
+      // `commit-and-tag-version` depends on an old version of lru-cache, which TypeScript
+      // doesn't agree with the typings of. Skip checking those files to make the build succeed.
+      skipLibCheck: true,
+    },
+  },
 });
 
 // Necessary to work around a typing issue in transitive dependency lru-cache@10 now that we've moved to a modern TS
-project.package.addPackageResolutions('lru-cache@^11');
+// project.package.addPackageResolutions('lru-cache@^11');
 
 // we can't use 9.x because it doesn't work with node 10.
 const fsExtraVersion = '^8.0.0';

--- a/package.json
+++ b/package.json
@@ -86,9 +86,6 @@
     "yargs": "^17",
     "zx": "^8.5.4"
   },
-  "resolutions": {
-    "lru-cache": "^11"
-  },
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/cdklabs/publib",

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -23,7 +23,8 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,10 +4774,24 @@ lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lru-cache@^10.2.0, lru-cache@^10.4.3, lru-cache@^11, lru-cache@^5.1.1, lru-cache@^6.0.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.1.0.tgz#afafb060607108132dbc1cf8ae661afb69486117"
-  integrity sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==
+lru-cache@^10.2.0, lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 make-dir@^4.0.0:
   version "4.0.0"
@@ -6565,6 +6579,16 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^2.2.2, yaml@^2.5.1:
   version "2.5.1"


### PR DESCRIPTION
`commit-and-tag-version@12` depends on a version of `lru-cache`, which fails typechecking of its definition files on modern TypeScript versions.

Disable lib checking to get the build to pass.

Undo the previous attempted fix which was to upgrade the version. It made the build pass but it broke `commit-and-tag-version` at runtime.