### PR TITLE
fix(publib-maven): fails with "Subprocess failed with exit code 1"

### DIFF
--- a/src/bin/publib-maven.ts
+++ b/src/bin/publib-maven.ts
@@ -485,7 +485,9 @@ async function importGpgKey(key: PrivateKey) {
   // GnuPG will occasionally bail out with "gpg: <whatever> failed: Inappropriate ioctl for device", the following attempts to fix
   const gpgHome = autoCleanDir();
   try {
-    const tty = (await $({ stdio: ['inherit', 'pipe', 'pipe'] })`tty`).stdout;
+    // In CI environments there will be no tty, and we don't want this to stop the script.
+    // The variable will be populated with a nonsensical string ("not a tty") but that doesn't seem to matter.
+    const tty = (await $({ stdio: ['inherit', 'pipe', 'pipe'], nothrow: true })`tty`).stdout;
 
     let privateKeyFile;
     const type = key.type;


### PR DESCRIPTION
In the old bash version, we had the following command:

```sh
set -eu

some_function() {
    export GPG_TTY=$(tty)
}
```

If there is no tty, this fails with exit code 1 but that doesn't stop the script if the failing subshell is part of an `export` command.

On GitHub Actions there is no tty which didn't stop the original script, but *does* stop the new script.

Configure `nothrow: true` on the `tty` subshell to avoid stopping the command.
