### PR TITLE
fix: disable progress display

### DIFF
--- a/src/bin/publib-maven.ts
+++ b/src/bin/publib-maven.ts
@@ -577,6 +577,7 @@ class Maven {
   public async exec(mojo: string, options: MavenExecOptions): Promise<ProcessOutput | undefined> {
     const args = [
       `--settings=${this.settingsFile}`,
+      '--batch-mode',
       ...(options.verbose ?? this.verbose ? ['-X'] : []),
       mojo,
       ...Object.entries(options.properties).map(([k, v]) => `-D${k}=${v}`),


### PR DESCRIPTION
A lot of the output of Maven looks like this:

```
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
Progress (2): 54 MB | 193/259 MB
```

Enable batch mode to disable progress reporting (according to Stack Overflow).

Fixes #