### PR TITLE
chore!: drop support for Node 6  BREAKING CHANGE: use JavaScript features not available in Node 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
-    "integ": "npx projen integ",
+    "integ": "npx projen integ && aws sts get-caller-identity && echo \"Running actual integration tests\" && node tests/run-integration-tests.js",
     "package": "npx projen package",
     "package-legacy": "npx projen package-legacy",
     "post-compile": "npx projen post-compile",


### PR DESCRIPTION
chore!: drop support for Node 6

BREAKING CHANGE: use JavaScript features not available in Node 6.



hackerone: mainteemoforfun