### PR TITLE
fix: fix twine --skip-existing errors

### DIFF
--- a/bin/publib-pypi
+++ b/bin/publib-pypi
@@ -40,7 +40,7 @@ fi
 upload_opts="--verbose --skip-existing"
 
 # Install required packages
-packages="twine"
+packages="'twine<6.2.0'"
 if [ -n "${PYPI_TRUSTED_PUBLISHER:-}" ]; then
   packages="$packages id"
 


### PR DESCRIPTION
I realize this is a temporary fix. However, python publishing is broken and I'd like to get that fixed to buy time to figure out the correct target state.

Temporarily addresses #1716.