### PR TITLE
fix(pypi): ERROR: Invalid requirement: "'twine<6.2.0'"

### DIFF
--- a/bin/publib-pypi
+++ b/bin/publib-pypi
@@ -40,7 +40,7 @@ fi
 upload_opts="--verbose --skip-existing"
 
 # Install required packages
-packages="'twine<6.2.0'"
+packages="twine<6.2.0"
 if [ -n "${PYPI_TRUSTED_PUBLISHER:-}" ]; then
   packages="$packages id"
 


### PR DESCRIPTION
https://github.com/cdklabs/publib/pull/1718 attempted to pin the Twine version as a hotfix to the `--skip-existing` error with CodeArtifact (https://github.com/cdklabs/publib/issues/1716).

The escaping ended up being wrong and the install doesn't work. Fixing the package string and this time I tested it.
