### PR TITLE
feat(nuget): add trusted publisher support with OIDC authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,14 +188,14 @@ npx publib-nuget [DIR]
 
 **Options (environment variables):**
 
-| Option                   | Required                                         | Description                                                                                                                                                        |
-| ------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `NUGET_API_KEY`          | Optional                                         | [NuGet API Key](https://www.nuget.org/account/apikeys) with "Push" permissions. Not required when using Trusted Publishers. When using Trusted Publishers, if provided, this key will be used instead of generating a temporary one. |
-| `NUGET_TRUSTED_PUBLISHER` | Optional                                         | Set to any value to use NuGet [Trusted Publisher](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) authentication (OIDC). Requires a supported ambient identity (i.e. CI/CD environment). |
-| `NUGET_USERNAME`         | Required when using Trusted Publishers           | NuGet.org username (profile name, not email address) for Trusted Publisher authentication.                                                                         |
-| `NUGET_SERVER`           | Optional                                         | NuGet Server URL (defaults to nuget.org)                                                                                                                           |
-| `NUGET_AUDIENCE`         | Optional                                         | OIDC audience for token generation (defaults to `https://www.nuget.org`)                                                                                           |
-| `NUGET_TOKEN_SERVICE_URL` | Optional                                         | NuGet token service endpoint (defaults to `https://www.nuget.org/api/v2/token`)                                                                                   |
+| Option                    | Required                   | Description                                                                                                                                                                                                       |
+| ------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NUGET_TRUSTED_PUBLISHER` | Optional                   | Set to any value to use NuGet [Trusted Publisher](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) authentication (OIDC). Requires a supported ambient identity (i.e. CI/CD environment).    |
+| `NUGET_USERNAME`          | for Trusted Publisher auth | NuGet.org username (profile name, not email address) for Trusted Publisher authentication.                                                                                                                        |
+| `NUGET_AUDIENCE`          | Optional                   | OIDC audience for token generation (defaults to `https://www.nuget.org`)                                                                                                                                          |
+| `NUGET_TOKEN_SERVICE_URL` | Optional                   | NuGet token service endpoint (defaults to `https://www.nuget.org/api/v2/token`)                                                                                                                                   |
+| `NUGET_API_KEY`           | Optional                   | [NuGet API Key](https://www.nuget.org/account/apikeys) with "Push" permissions. Not required when using Trusted Publishers. Also set to use a short-lived NuGet API key via e.g. <https://github.com/NuGet/login> |
+| `NUGET_SERVER`            | Optional                   | NuGet Server URL (defaults to nuget.org)                                                                                                                                                                          |
 
 ### Trusted Publishers
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ npx publib-nuget [DIR]
 ### Trusted Publishers
 
 NuGet [Trusted Publishers](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) allows publishing without API keys by using OpenID Connect (OIDC) authentication between a trusted third-party service and NuGet.org.
-Supports multiple CI/CD providers including GitHub Actions, GitLab CI/CD, Google Cloud, Buildkite, and CircleCI.
 
 **Trusted Publisher Setup:**
 
@@ -212,7 +211,6 @@ Supports multiple CI/CD providers including GitHub Actions, GitLab CI/CD, Google
 **Requirements:**
 
 * **GitHub Actions**: Your workflow must have `id-token: write` permission.
-* **GitLab CI/CD**: The keyword `id_tokens` is used to request an OIDC token from GitLab with name `NUGET_ID_TOKEN` and audience `https://www.nuget.org`.
 * **Python 3**: Required when using Trusted Publishers without providing `NUGET_API_KEY`. The `id` package is automatically installed.
 
 **Publish to GitHub Packages**\

--- a/README.md
+++ b/README.md
@@ -188,10 +188,32 @@ npx publib-nuget [DIR]
 
 **Options (environment variables):**
 
-| Option          | Required | Description                                                                    |
-| --------------- | -------- | ------------------------------------------------------------------------------ |
-| `NUGET_API_KEY` | Required | [NuGet API Key](https://www.nuget.org/account/apikeys) with "Push" permissions |
-| `NUGET_SERVER`  | Optional | NuGet Server URL (defaults to nuget.org)                                       |
+| Option                   | Required                                         | Description                                                                                                                                                        |
+| ------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `NUGET_API_KEY`          | Optional                                         | [NuGet API Key](https://www.nuget.org/account/apikeys) with "Push" permissions. Not required when using Trusted Publishers. When using Trusted Publishers, if provided, this key will be used instead of generating a temporary one. |
+| `NUGET_TRUSTED_PUBLISHER` | Optional                                         | Set to any value to use NuGet [Trusted Publisher](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) authentication (OIDC). Requires a supported ambient identity (i.e. CI/CD environment). |
+| `NUGET_USERNAME`         | Required when using Trusted Publishers           | NuGet.org username (profile name, not email address) for Trusted Publisher authentication.                                                                         |
+| `NUGET_SERVER`           | Optional                                         | NuGet Server URL (defaults to nuget.org)                                                                                                                           |
+| `NUGET_AUDIENCE`         | Optional                                         | OIDC audience for token generation (defaults to `https://www.nuget.org`)                                                                                           |
+| `NUGET_TOKEN_SERVICE_URL` | Optional                                         | NuGet token service endpoint (defaults to `https://www.nuget.org/api/v2/token`)                                                                                   |
+
+### Trusted Publishers
+
+NuGet [Trusted Publishers](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) allows publishing without API keys by using OpenID Connect (OIDC) authentication between a trusted third-party service and NuGet.org.
+Supports multiple CI/CD providers including GitHub Actions, GitLab CI/CD, Google Cloud, Buildkite, and CircleCI.
+
+**Trusted Publisher Setup:**
+
+1. Configure your NuGet.org project to use a [Trusted Publisher](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
+2. Set `NUGET_TRUSTED_PUBLISHER=1` in your workflow environment
+3. Set `NUGET_USERNAME` to your NuGet.org username (profile name)
+4. No `NUGET_API_KEY` needed
+
+**Requirements:**
+
+* **GitHub Actions**: Your workflow must have `id-token: write` permission.
+* **GitLab CI/CD**: The keyword `id_tokens` is used to request an OIDC token from GitLab with name `NUGET_ID_TOKEN` and audience `https://www.nuget.org`.
+* **Python 3**: Required when using Trusted Publishers without providing `NUGET_API_KEY`. The `id` package is automatically installed.
 
 **Publish to GitHub Packages**\
 You can publish to GitHub Packages instead, with the following options:

--- a/bin/publib-nuget
+++ b/bin/publib-nuget
@@ -10,12 +10,20 @@ set -eu # we don't want "pipefail" to implement idempotency
 #
 # DIR is a directory with *.nupkg files (default is 'dist/dotnet')
 #
-# NUGET_API_KEY (optional): API key for nuget (ignored when using Trusted Publishers)
-# NUGET_TRUSTED_PUBLISHER (optional): set to any value to use Trusted Publisher authentication
-# NUGET_USERNAME (required when using Trusted Publishers): NuGet.org username
-# NUGET_AUDIENCE (optional): OIDC audience for token generation (defaults to https://www.nuget.org)
-# NUGET_TOKEN_SERVICE_URL (optional): NuGet token service endpoint (defaults to https://www.nuget.org/api/v2/token)
+# Two publishing modes are supported: Trusted Publisher (recommended) and API key (legacy).
+# Set environment variables accordingly.
 #
+# Trusted Publisher (recommended):
+# - NUGET_TRUSTED_PUBLISHER (required): set to any value
+# - NUGET_USERNAME (required): the NuGet.org username of the package owner
+# - NUGET_AUDIENCE (optional): OIDC audience for token generation (defaults to https://www.nuget.org)
+# - NUGET_TOKEN_SERVICE_URL (optional): NuGet token service endpoint (defaults to https://www.nuget.org/api/v2/token)#
+#
+# API Key:
+# - NUGET_API_KEY (required): API key for your account, created on nuget.org or use https://github.com/NuGet/login
+#
+# Generic options:
+# - NUGET_SERVER (optional): different NuGet server URL to use
 ###
 
 cd "${1:-"dist/dotnet"}"
@@ -29,32 +37,27 @@ if [ -n "${NUGET_TRUSTED_PUBLISHER:-}" ]; then
         exit 1
     fi
     
-    # Use provided API key if available, otherwise generate one
-    if [ -n "${NUGET_API_KEY:-}" ]; then
-        echo "Using provided NUGET_API_KEY"
-    else
-        # Install required packages
-        python3 -m pip install --user --upgrade id
-        
-        # Generate OIDC token using the id package
-        nuget_audience="${NUGET_AUDIENCE:-https://www.nuget.org}"
-        oidc_token=$(python3 -m id "$nuget_audience")
-        
-        # Exchange OIDC token for NuGet API key
-        nuget_token_service_url="${NUGET_TOKEN_SERVICE_URL:-https://www.nuget.org/api/v2/token}"
-        token_request_body=$(jq -n --arg username "$NUGET_USERNAME" '{username: $username, tokenType: "ApiKey"}')
-        
-        NUGET_API_KEY=$(curl -s -X POST \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H "User-Agent: publib/nuget-publisher" \
-            -d "$token_request_body" \
-            "$nuget_token_service_url" | jq -r '.apiKey')
-        
-        if [ "$NUGET_API_KEY" = "null" ] || [ -z "$NUGET_API_KEY" ]; then
-            echo "Failed to exchange OIDC token for NuGet API key"
-            exit 1
-        fi
+    # Install required packages
+    python3 -m pip install --user --upgrade id
+    
+    # Generate OIDC token using the id package
+    nuget_audience="${NUGET_AUDIENCE:-https://www.nuget.org}"
+    oidc_token=$(python3 -m id "$nuget_audience")
+    
+    # Exchange OIDC token for NuGet API key
+    nuget_token_service_url="${NUGET_TOKEN_SERVICE_URL:-https://www.nuget.org/api/v2/token}"
+    token_request_body=$(jq -n --arg username "$NUGET_USERNAME" '{username: $username, tokenType: "ApiKey"}')
+    
+    NUGET_API_KEY=$(curl -s -X POST \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${oidc_token}" \
+        -H "User-Agent: publib/nuget-publisher" \
+        -d "$token_request_body" \
+        "$nuget_token_service_url" | jq -r '.apiKey')
+    
+    if [ "$NUGET_API_KEY" = "null" ] || [ -z "$NUGET_API_KEY" ]; then
+        echo "Failed to exchange OIDC token for NuGet API key"
+        exit 1
     fi
 elif [ -z "${NUGET_API_KEY:-}" ]; then
     echo "NUGET_API_KEY is required or set NUGET_TRUSTED_PUBLISHER=1 with NUGET_USERNAME"

--- a/bin/publib-nuget
+++ b/bin/publib-nuget
@@ -10,14 +10,54 @@ set -eu # we don't want "pipefail" to implement idempotency
 #
 # DIR is a directory with *.nupkg files (default is 'dist/dotnet')
 #
-# NUGET_API_KEY (required): API key for nuget
+# NUGET_API_KEY (optional): API key for nuget (ignored when using Trusted Publishers)
+# NUGET_TRUSTED_PUBLISHER (optional): set to any value to use Trusted Publisher authentication
+# NUGET_USERNAME (required when using Trusted Publishers): NuGet.org username
+# NUGET_AUDIENCE (optional): OIDC audience for token generation (defaults to https://www.nuget.org)
+# NUGET_TOKEN_SERVICE_URL (optional): NuGet token service endpoint (defaults to https://www.nuget.org/api/v2/token)
 #
 ###
 
 cd "${1:-"dist/dotnet"}"
 
-if [ -z "${NUGET_API_KEY:-}" ]; then
-    echo "NUGET_API_KEY is required"
+# Check for Trusted Publisher authentication
+if [ -n "${NUGET_TRUSTED_PUBLISHER:-}" ]; then
+    echo "Using NuGet Trusted Publisher authentication"
+    
+    if [ -z "${NUGET_USERNAME:-}" ]; then
+        echo "NUGET_USERNAME is required when using Trusted Publishers"
+        exit 1
+    fi
+    
+    # Use provided API key if available, otherwise generate one
+    if [ -n "${NUGET_API_KEY:-}" ]; then
+        echo "Using provided NUGET_API_KEY"
+    else
+        # Install required packages
+        python3 -m pip install --user --upgrade id
+        
+        # Generate OIDC token using the id package
+        nuget_audience="${NUGET_AUDIENCE:-https://www.nuget.org}"
+        oidc_token=$(python3 -m id "$nuget_audience")
+        
+        # Exchange OIDC token for NuGet API key
+        nuget_token_service_url="${NUGET_TOKEN_SERVICE_URL:-https://www.nuget.org/api/v2/token}"
+        token_request_body=$(jq -n --arg username "$NUGET_USERNAME" '{username: $username, tokenType: "ApiKey"}')
+        
+        NUGET_API_KEY=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H "User-Agent: publib/nuget-publisher" \
+            -d "$token_request_body" \
+            "$nuget_token_service_url" | jq -r '.apiKey')
+        
+        if [ "$NUGET_API_KEY" = "null" ] || [ -z "$NUGET_API_KEY" ]; then
+            echo "Failed to exchange OIDC token for NuGet API key"
+            exit 1
+        fi
+    fi
+elif [ -z "${NUGET_API_KEY:-}" ]; then
+    echo "NUGET_API_KEY is required or set NUGET_TRUSTED_PUBLISHER=1 with NUGET_USERNAME"
     exit 1
 fi
 


### PR DESCRIPTION
Implements NuGet Trusted Publishing to enable secure, keyless publishing using GitHub Actions OIDC tokens instead of long-lived API keys.

Reference: https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing

## Changes

- **Enhanced `publib-nuget`**: Added OIDC token exchange functionality
  - Detects `NUGET_TRUSTED_PUBLISHER` environment variable
  - Validates required `NUGET_USERNAME` for trusted publishing
  - Exchanges GitHub OIDC token for temporary NuGet API key
  - Maintains backward compatibility with existing `NUGET_API_KEY` workflow

- **Updated `README.md`**: Added comprehensive documentation
  - New environment variables (`NUGET_TRUSTED_PUBLISHER`, `NUGET_USERNAME`)
  - Trusted Publisher setup instructions
  - GitHub Actions requirements (`id-token: write` permission)

## Benefits

- Eliminates need for long-lived API keys
- Reduces risk of credential leaks
- Follows industry best practices for secure publishing
- Seamless integration with existing workflows

## Testing

Verified error handling for missing environment variables and proper fallback to traditional API key authentication.
