### PR TITLE
feat: unified dry run mode via PUBLIB_DRYRUN

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ You can also execute individual publishers:
 * `publib-pypi`
 * `publib-golang`
 
+## Dry Run
+
+All publishers support a dry run mode via the `PUBLIB_DRYRUN` environment variable.
+Set `PUBLIB_DRYRUN=true` to skip actual publishing across all targets:
+
+```shell
+PUBLIB_DRYRUN=true publib
+```
+
 ## npm
 
 Publishes all `*.tgz` files from `DIR` to [npmjs](npmjs.com), [GitHub Packages](https://github.com/features/packages) or [AWS CodeArtifact](https://aws.amazon.com/codeartifact/).
@@ -116,7 +125,7 @@ The server type is selected using the `MAVEN_SERVER_ID` variable.
 | -------------------- | --------------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | (all)                | `MAVEN_SERVER_ID`                                                     | Yes going forward | Either `ossrh` (default but deprecated), `central-ossrh`, or any other string for a custom Nexus server.                                                                                                                                                                                                                                                                  |
 | (all)                | `MAVEN_USERNAME` and `MAVEN_PASSWORD`                                 | Yes               | Username and password for maven repository. For Maven Central, you will need to [Create JIRA account](https://issues.sonatype.org/secure/Signup!default.jspa) and then request a [new project](https://issues.sonatype.org/secure/CreateIssue.jspa?issuetype=21&pid=10134). Read the [OSSRH guide](https://central.sonatype.org/pages/ossrh-guide.html) for more details. |
-| (all)                | `MAVEN_DRYRUN`                                                        | No                | Set to "true" for a dry run                                                                                                                                                                                                                                                                                                                                               |
+| (all)                | `MAVEN_DRYRUN`                                                        | No                | Deprecated. Use `PUBLIB_DRYRUN` instead. Set to "true" for a dry run                                                                                                                                                                                                                                                                                                      |
 | (all)                | `MAVEN_VERBOSE`                                                       | No                | Make Maven print debug output if set to `true`                                                                                                                                                                                                                                                                                                                            |
 | `central-ossrh`      | `MAVEN_GPG_PRIVATE_KEY[_FILE]` and `MAVEN_GPG_PRIVATE_KEY_PASSPHRASE` | Yes               | GPG private key or file that includes it. This is used to sign your Maven packages. See instructions below                                                                                                                                                                                                                                                                |
 | `central-ossrh`      | `MAVEN_ENDPOINT`                                                      | No                | URL of Nexus repository. Defaults to `https://ossrh-staging-api.central.sonatype.com/`.                                                                                                                                                                                                                                                                                   |
@@ -295,7 +304,7 @@ Repository tags will be in the following format:
 | `GIT_USER_EMAIL`                                      | Optional                                         | Email to perform the commit with. Defaults to the git user.email config in the current directory. Fails if it doesn't exist.                                                                                                                         |
 | `GIT_COMMIT_MESSAGE`                                  | Optional                                         | The commit message. Defaults to 'chore(release): $VERSION'.                                                                                                                                                                                          |
 | `GIT_CLONE_DEPTH`                                     | Optional                                         | The git clone depth. Usually only the latest commit is required. Defaults to 1.                                                                                                                                                                      |
-| `DRYRUN`                                              | Optional                                         | Set to "true" for a dry run.                                                                                                                                                                                                                         |
+| `DRYRUN`                                              | Optional                                         | Deprecated. Use `PUBLIB_DRYRUN` instead. Set to "true" for a dry run.                                                                                                                                                                                |
 
 ## Publish to CodeArtifact for testing
 

--- a/bin/publib-npm
+++ b/bin/publib-npm
@@ -83,6 +83,16 @@ fi
 
 log=$(mktemp -d)/npmlog.txt
 
+# Check for dry run
+if [ "${PUBLIB_DRYRUN:-}" = "true" ]; then
+  echo "🏜️ Dry run: skipping npm publish"
+  for file in ${dir}/**.tgz; do
+    echo "  (would publish ${file})"
+  done
+  echo "SUCCESS (dry run)"
+  exit 0
+fi
+
 for file in ${dir}/**.tgz; do
   npm publish ${tag} ${access} ${file} 2>&1 | tee ${log}
   exit_code="${PIPESTATUS[0]}"

--- a/bin/publib-nuget
+++ b/bin/publib-nuget
@@ -78,6 +78,16 @@ fi
 
 echo "Publishing NuGet packages..."
 
+# Check for dry run
+if [ "${PUBLIB_DRYRUN:-}" = "true" ]; then
+  echo "🏜️ Dry run: skipping NuGet publish"
+  for package_dir in ${packages}; do
+    echo "  (would publish ${package_dir})"
+  done
+  echo "✅ All Done! (dry run)"
+  exit 0
+fi
+
 nuget_source="${NUGET_SERVER:-"https://api.nuget.org/v3/index.json"}"
 nuget_symbol_source="https://nuget.smbsrc.net/"
 

--- a/bin/publib-pypi
+++ b/bin/publib-pypi
@@ -85,5 +85,15 @@ if [ "$use_trusted_publisher" = "true" ]; then
   fi
 fi
 
+# Check for dry run
+if [ "${PUBLIB_DRYRUN:-}" = "true" ]; then
+  echo "🏜️ Dry run: skipping PyPI upload"
+  for file in *.whl; do
+    echo "  (would upload ${file})"
+  done
+  echo "SUCCESS (dry run)"
+  exit 0
+fi
+
 echo "Uploading packages to PyPI"
 python3 -m twine upload $upload_opts *

--- a/src/bin/publib-golang.ts
+++ b/src/bin/publib-golang.ts
@@ -4,7 +4,7 @@ import * as go from '../targets/go';
 const releaser = new go.GoReleaser({
   dir: process.argv[2],
   branch: process.env.GIT_BRANCH,
-  dryRun: (process.env.DRYRUN ?? 'false').toLowerCase() === 'true',
+  dryRun: (process.env.PUBLIB_DRYRUN ?? process.env.DRYRUN ?? 'false').toLowerCase() === 'true',
   email: process.env.GIT_USER_EMAIL,
   username: process.env.GIT_USER_NAME,
   version: process.env.VERSION,

--- a/src/bin/publib-maven.ts
+++ b/src/bin/publib-maven.ts
@@ -48,7 +48,7 @@ async function main() {
   const sharedOptions: SharedPublishOptions = {
     username: envVar('MAVEN_USERNAME'),
     password: envVar('MAVEN_PASSWORD'),
-    dryRun: process.env.MAVEN_DRYRUN === 'true',
+    dryRun: process.env.MAVEN_DRYRUN === 'true' || process.env.PUBLIB_DRYRUN === 'true',
     verbose: process.env.MAVEN_VERBOSE === 'true',
     poms,
   };


### PR DESCRIPTION
All publishers now support a single `PUBLIB_DRYRUN=true` environment variable to skip actual publishing. Previously only Maven and Golang had dry run support via their own variables.

The existing `MAVEN_DRYRUN` and `DRYRUN` (golang) variables continue to work but are marked as deprecated in the documentation.
