### PR TITLE
chore: fix integ test

### DIFF
--- a/test/publib-ca.integ.ts
+++ b/test/publib-ca.integ.ts
@@ -53,5 +53,5 @@ test('can create an NPM package, publish and consume it from CodeArtifact', asyn
 
 async function publibCa(args: string[]) {
   const cli = path.resolve(__dirname, '../src/bin/publib-ca.ts');
-  return shell(['ts-node', cli, ...args], { captureStderr: false });
+  return shell(['tsx', cli, ...args], { captureStderr: false });
 }


### PR DESCRIPTION
Fixes the failing integ test after #1824 merged. This was not testable since the integ test workflow needed to be merged first.