### PR TITLE
feat: add publib-github command for creating GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You can also execute individual publishers:
 * `publib-npm`
 * `publib-pypi`
 * `publib-golang`
+* `publib-github`
 
 ## Dry Run
 
@@ -304,6 +305,34 @@ Repository tags will be in the following format:
 | `GIT_COMMIT_MESSAGE`                                  | Optional                                         | The commit message. Defaults to 'chore(release): $VERSION'.                                                                                                                                                                                          |
 | `GIT_CLONE_DEPTH`                                     | Optional                                         | The git clone depth. Usually only the latest commit is required. Defaults to 1.                                                                                                                                                                      |
 | `DRYRUN`                                              | Optional                                         | Deprecated. Use `PUBLIB_DRYRUN` instead. Set to "true" for a dry run.                                                                                                                                                                                |
+
+## GitHub Releases
+
+Creates a [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) for a tag.
+
+If a release for the tag already exists, the command succeeds without touching
+the existing release, so that re-running a (partially failed) release workflow
+is a no-op rather than a failure.
+
+**Usage:**
+
+```shell
+npx publib-github
+```
+
+**Options (environment variables):**
+
+| Option                    | Required                                             | Description                                                                                                                                                                                             |
+| ------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITHUB_TOKEN`            | Required                                             | Token used to authenticate against the GitHub API. Requires `contents: write` permission.                                                                                                               |
+| `GITHUB_REPOSITORY`       | Required                                             | The repository to release to, in `owner/repo` format. Set automatically in [GitHub Actions workflows](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables). |
+| `GITHUB_RELEASE_TAG`      | Either this or `GITHUB_RELEASE_TAG_FILE` is required | The tag to release (e.g. `v1.2.3`).                                                                                                                                                                     |
+| `GITHUB_RELEASE_TAG_FILE` | Either this or `GITHUB_RELEASE_TAG` is required      | A file containing the tag to release (e.g. `dist/releasetag.txt`).                                                                                                                                      |
+| `GITHUB_CHANGELOG_FILE`   | Optional                                             | A markdown file used as the release notes (e.g. `dist/changelog.md`).                                                                                                                                   |
+| `GITHUB_SHA`              | Optional                                             | The commit to tag if the tag doesn't exist yet. Ignored if the tag already exists. Defaults to the repository's default branch. Set automatically in GitHub Actions workflows.                          |
+| `GITHUB_PRERELEASE`       | Optional                                             | Set to "true" to mark the release as a prerelease.                                                                                                                                                      |
+| `GITHUB_MARK_LATEST`      | Optional                                             | `true` to explicitly mark the release as the latest release, `false` to explicitly not mark it as latest. Defaults to GitHub determining the latest release.                                            |
+| `GITHUB_API_URL`          | Optional                                             | Base URL of the GitHub API, for GitHub Enterprise instances. Defaults to `https://api.github.com`. Set automatically in GitHub Actions workflows.                                                       |
 
 ## Publish to CodeArtifact for testing
 

--- a/bin/publib-github
+++ b/bin/publib-github
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/bin/publib-github.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "bin": {
         "jsii-release": "bin/jsii-release-shim",
         "jsii-release-ca": "bin/jsii-release-shim",
+        "jsii-release-github": "bin/jsii-release-shim",
         "jsii-release-golang": "bin/jsii-release-shim",
         "jsii-release-maven": "bin/jsii-release-shim",
         "jsii-release-npm": "bin/jsii-release-shim",
@@ -28,6 +29,7 @@
         "jsii-release-shim": "bin/jsii-release-shim",
         "publib": "bin/publib",
         "publib-ca": "bin/publib-ca",
+        "publib-github": "bin/publib-github",
         "publib-golang": "bin/publib-golang",
         "publib-maven": "bin/publib-maven",
         "publib-npm": "bin/publib-npm",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "bin": {
     "jsii-release": "./bin/jsii-release-shim",
     "jsii-release-ca": "./bin/jsii-release-shim",
+    "jsii-release-github": "./bin/jsii-release-shim",
     "jsii-release-golang": "./bin/jsii-release-shim",
     "jsii-release-maven": "./bin/jsii-release-shim",
     "jsii-release-npm": "./bin/jsii-release-shim",
@@ -16,6 +17,7 @@
     "jsii-release-shim": "bin/jsii-release-shim",
     "publib": "bin/publib",
     "publib-ca": "bin/publib-ca",
+    "publib-github": "bin/publib-github",
     "publib-golang": "bin/publib-golang",
     "publib-maven": "bin/publib-maven",
     "publib-npm": "bin/publib-npm",

--- a/src/bin/publib-github.ts
+++ b/src/bin/publib-github.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Creates a GitHub release, tolerating a release that already exists so that
+ * re-running a release is a no-op rather than a failure.
+ *
+ * Usage: publib-github
+ *
+ * GITHUB_TOKEN (required): token used to authenticate against the GitHub API
+ * GITHUB_RELEASE_TAG (optional): the tag to release; either this or GITHUB_RELEASE_TAG_FILE is required
+ * GITHUB_RELEASE_TAG_FILE (optional): a file containing the tag to release
+ * GITHUB_CHANGELOG_FILE (optional): a markdown file used as the release notes
+ * GITHUB_REPOSITORY (optional): the repository to release to, in `owner/repo` format (defaults to the repository of the "origin" remote in the current directory)
+ * GITHUB_SHA (optional): the commit to tag if the tag doesn't exist yet (defaults to the current git HEAD, or the repository's default branch when not in a git repository)
+ * GITHUB_PRERELEASE (optional): set to "true" to mark the release as a prerelease
+ * GITHUB_MARK_LATEST (optional): "true" to explicitly mark the release as the latest release, "false" to explicitly not mark it as latest (defaults to GitHub determining the latest release)
+ * GITHUB_API_URL (optional): base URL of the GitHub API (defaults to "https://api.github.com"; set automatically in GitHub Actions)
+ * PUBLIB_DRYRUN (optional): set to "true" to print what would be done without creating a release
+ */
+import { readFileSync } from 'fs';
+import * as git from '../help/git';
+import { createGitHubRelease } from '../targets/github';
+
+async function main() {
+  const repository = optionalEnv('GITHUB_REPOSITORY') ?? git.repositorySlug();
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY is required, could not infer the repository from the "origin" remote');
+  }
+  const tag = releaseTag();
+  const changelogFile = optionalEnv('GITHUB_CHANGELOG_FILE');
+  const body = changelogFile ? readFileSync(changelogFile, 'utf-8') : undefined;
+  const target = optionalEnv('GITHUB_SHA') ?? git.head();
+  const prerelease = (optionalEnv('GITHUB_PRERELEASE') ?? 'false').toLowerCase() === 'true';
+  const latest = parseMarkLatest(optionalEnv('GITHUB_MARK_LATEST'));
+  const dryRun = (process.env.PUBLIB_DRYRUN ?? process.env.DRYRUN ?? 'false').toLowerCase() === 'true';
+
+  if (dryRun) {
+    console.log(
+      `🏜️ Dry run: would create GitHub release ${tag}${prerelease ? ' (prerelease)' : ''} in ${repository}${target ? ` at ${target}` : ''}`,
+    );
+    console.log('SUCCESS (dry run)');
+    return;
+  }
+
+  const result = await createGitHubRelease({
+    tag,
+    repository,
+    body,
+    target,
+    prerelease,
+    latest,
+    token: requireEnv('GITHUB_TOKEN'),
+    apiUrl: optionalEnv('GITHUB_API_URL'),
+  });
+
+  if (result === 'already_exists') {
+    console.log(`SKIPPING: release ${tag} already exists`);
+  } else {
+    console.log(`SUCCESS: created release ${tag}`);
+  }
+}
+
+function releaseTag(): string {
+  const explicitTag = optionalEnv('GITHUB_RELEASE_TAG');
+  if (explicitTag) {
+    return explicitTag;
+  }
+  const tagFile = optionalEnv('GITHUB_RELEASE_TAG_FILE');
+  if (!tagFile) {
+    throw new Error('GITHUB_RELEASE_TAG or GITHUB_RELEASE_TAG_FILE is required');
+  }
+  const tag = readFileSync(tagFile, 'utf-8').trim();
+  if (!tag) {
+    throw new Error(`release tag file ${tagFile} is empty`);
+  }
+  return tag;
+}
+
+function parseMarkLatest(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === 'true' || value === 'false') {
+    return value === 'true';
+  }
+  throw new Error(`GITHUB_MARK_LATEST must be "true" or "false", got: "${value}"`);
+}
+
+/**
+ * Returns the value of the environment variable, treating an empty string as
+ * not set.
+ */
+function optionalEnv(name: string): string | undefined {
+  return process.env[name] ? process.env[name] : undefined;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+main().catch((error: Error) => {
+  console.error(`ERROR: ${error.message}`);
+  process.exit(1);
+});

--- a/src/help/git.ts
+++ b/src/help/git.ts
@@ -248,3 +248,55 @@ export function identify(user: string, address: string) {
 export function branchExistsOnRemote(repositoryUrl: string, branch: string): boolean {
   return shell.check(`git ls-remote --exit-code --heads ${tryDetectRepositoryUrl(repositoryUrl)} ${branch}`, { capture: true });
 }
+
+/**
+ * Returns the `owner/repo` slug of the `origin` remote in the current
+ * directory, or undefined if it cannot be determined (e.g. not in a git
+ * repository, or no `origin` remote configured).
+ */
+export function repositorySlug(): string | undefined {
+  try {
+    const url = shell.run('git remote get-url origin', { capture: true });
+    return parseRepositorySlug(url);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extracts the `owner/repo` slug from a git remote URL.
+ *
+ * Supports HTTPS (`https://github.com/owner/repo.git`), SSH
+ * (`git@github.com:owner/repo.git`, `ssh://git@github.com/owner/repo.git`)
+ * and URLs without a `.git` suffix.
+ *
+ * @returns the `owner/repo` slug, or undefined if it cannot be determined
+ */
+export function parseRepositorySlug(url: string): string | undefined {
+  const path = url
+    .trim()
+    .replace(/\.git$/, '')
+    // drop the scheme (https://, ssh://, git+ssh://, ...)
+    .replace(/^[a-z+]+:\/\//, '')
+    // normalize scp-like ssh syntax (git@host:owner/repo) to a path
+    .replace(/^git@[^:/]+[:/]/, '')
+    // strip a leading host segment (github.com/owner/repo)
+    .replace(/^[^/]+\.[^/]+\//, '');
+  const parts = path.split('/').filter(Boolean);
+  if (parts.length !== 2) {
+    return undefined;
+  }
+  return parts.join('/');
+}
+
+/**
+ * Returns the commit hash of HEAD in the current directory, or undefined if
+ * it cannot be determined (e.g. not in a git repository).
+ */
+export function head(): string | undefined {
+  try {
+    return shell.run('git rev-parse HEAD', { capture: true });
+  } catch {
+    return undefined;
+  }
+}

--- a/src/targets/github.ts
+++ b/src/targets/github.ts
@@ -1,0 +1,127 @@
+/**
+ * Creates GitHub releases via the GitHub REST API, tolerating a release that
+ * already exists so that re-running a release is a no-op rather than a
+ * failure.
+ */
+
+/**
+ * Options for creating a GitHub release.
+ */
+export interface GitHubReleaseOptions {
+  /**
+   * The tag name of the release (e.g. `v1.2.3`).
+   */
+  readonly tag: string;
+
+  /**
+   * The repository to release to, in `owner/repo` format.
+   */
+  readonly repository: string;
+
+  /**
+   * The token used to authenticate against the GitHub API.
+   */
+  readonly token: string;
+
+  /**
+   * Markdown body of the release (release notes).
+   *
+   * @default - no release notes
+   */
+  readonly body?: string;
+
+  /**
+   * The commitish the release tag will point to, if the tag does not exist
+   * yet. Ignored by GitHub when the tag already exists.
+   *
+   * @default - the repository's default branch
+   */
+  readonly target?: string;
+
+  /**
+   * Mark the release as a prerelease.
+   *
+   * @default false
+   */
+  readonly prerelease?: boolean;
+
+  /**
+   * Whether this release should be explicitly marked as the latest release
+   * (`true`) or explicitly not marked as the latest release (`false`).
+   *
+   * Passed to the GitHub API as `make_latest`.
+   *
+   * @default - not sent; GitHub determines the latest release
+   */
+  readonly latest?: boolean;
+
+  /**
+   * Base URL of the GitHub API.
+   *
+   * @default 'https://api.github.com'
+   */
+  readonly apiUrl?: string;
+}
+
+/**
+ * The outcome of `createGitHubRelease`.
+ */
+export type GitHubReleaseResult = 'created' | 'already_exists';
+
+/**
+ * Creates a GitHub release.
+ *
+ * Returns `'already_exists'` instead of failing when a release for the tag
+ * already exists, so that a re-run of a (partially failed) release workflow is
+ * a no-op rather than a failure. The existing release is left untouched. Any
+ * other error is thrown.
+ */
+export async function createGitHubRelease(options: GitHubReleaseOptions): Promise<GitHubReleaseResult> {
+  const apiUrl = (options.apiUrl ?? 'https://api.github.com').replace(/\/+$/, '');
+
+  const response = await fetch(`${apiUrl}/repos/${options.repository}/releases`, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `Bearer ${options.token}`,
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      tag_name: options.tag,
+      name: options.tag,
+      body: options.body ?? '',
+      prerelease: options.prerelease ?? false,
+      ...(options.target ? { target_commitish: options.target } : {}),
+      ...(options.latest !== undefined ? { make_latest: String(options.latest) } : {}),
+    }),
+  });
+
+  if (response.ok) {
+    return 'created';
+  }
+
+  const body = await response.text();
+  if (response.status === 422 && releaseAlreadyExists(body)) {
+    return 'already_exists';
+  }
+
+  throw new Error(`GitHub release creation failed: HTTP ${response.status} ${response.statusText}: ${body}`);
+}
+
+/**
+ * Whether a 422 response body indicates that a release for the tag already
+ * exists.
+ *
+ * The API reports this as
+ * `{ errors: [{ resource: 'Release', code: 'already_exists', field: 'tag_name' }] }`.
+ */
+function releaseAlreadyExists(responseBody: string): boolean {
+  try {
+    const parsed = JSON.parse(responseBody);
+    const errors: any[] = Array.isArray(parsed?.errors) ? parsed.errors : [];
+    return errors.some((e) => e?.resource === 'Release' && e?.code === 'already_exists');
+  } catch {
+    return false;
+  }
+}

--- a/test/publib-github.integ.ts
+++ b/test/publib-github.integ.ts
@@ -1,0 +1,76 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { inTemporaryDirectory } from './with-temporary-directory';
+import { shell } from '../src/codeartifact/shell';
+
+jest.setTimeout(60_000);
+
+/**
+ * Runs `publib-github` in dry-run mode. Clears the GitHub Actions default
+ * environment variables (unless overridden via `env`), so that value
+ * inference from the local git repository can be tested.
+ */
+async function publibGithubDryRun(env: Record<string, string> = {}) {
+  const cli = path.resolve(__dirname, '../src/bin/publib-github.ts');
+  return shell(['tsx', cli], {
+    captureStderr: true,
+    allowErrExit: true,
+    env: {
+      ...process.env,
+      PUBLIB_DRYRUN: 'true',
+      GITHUB_REPOSITORY: '',
+      GITHUB_SHA: '',
+      GITHUB_RELEASE_TAG: '',
+      GITHUB_RELEASE_TAG_FILE: '',
+      ...env,
+    },
+  });
+}
+
+test('dry run infers repository and commit from the local git repository', async () => {
+  await inTemporaryDirectory(async () => {
+    await shell('git init --initial-branch=main .');
+    await shell('git config user.name "publib integ test" && git config user.email "test@example.com"');
+    await fs.writeFile('some-file.txt', 'hello');
+    await shell('git add . && git commit -m "initial commit"');
+    await shell('git remote add origin git@github.com:cdklabs/publib-integ-test.git');
+    const head = await shell('git rev-parse HEAD');
+    await fs.writeFile('releasetag.txt', 'v0.1.1\n');
+
+    const output = await publibGithubDryRun({
+      GITHUB_RELEASE_TAG_FILE: 'releasetag.txt',
+    });
+
+    expect(output).toContain(
+      `would create GitHub release v0.1.1 in cdklabs/publib-integ-test at ${head}`,
+    );
+    expect(output).toContain('SUCCESS (dry run)');
+  });
+});
+
+test('dry run prefers explicit environment variables over inferred values', async () => {
+  await inTemporaryDirectory(async () => {
+    const output = await publibGithubDryRun({
+      GITHUB_REPOSITORY: 'explicit/repository',
+      GITHUB_SHA: 'explicit-sha',
+      GITHUB_RELEASE_TAG: 'v9.9.9',
+      GITHUB_PRERELEASE: 'true',
+    });
+
+    expect(output).toContain(
+      'would create GitHub release v9.9.9 (prerelease) in explicit/repository at explicit-sha',
+    );
+    expect(output).toContain('SUCCESS (dry run)');
+  });
+});
+
+test('dry run fails with actionable error when the repository cannot be determined', async () => {
+  await inTemporaryDirectory(async () => {
+    const output = await publibGithubDryRun({
+      GITHUB_RELEASE_TAG: 'v9.9.9',
+    });
+
+    expect(output).toContain('GITHUB_REPOSITORY is required');
+  });
+});

--- a/test/targets/git.test.ts
+++ b/test/targets/git.test.ts
@@ -33,3 +33,41 @@ function withTmpDir(fn: (tmpDir: string) => void) {
     process.chdir(cwd);
   }
 }
+
+test.each([
+  ['https://github.com/cdklabs/publib.git', 'cdklabs/publib'],
+  ['https://github.com/cdklabs/publib', 'cdklabs/publib'],
+  ['git@github.com:cdklabs/publib.git', 'cdklabs/publib'],
+  ['ssh://git@github.com/cdklabs/publib.git', 'cdklabs/publib'],
+  ['https://github.corporate-enterprise.com/cdklabs/publib.git', 'cdklabs/publib'],
+  ['not-a-url', undefined],
+  ['', undefined],
+])('parseRepositorySlug(%s) returns %s', (url, expected) => {
+  expect(git.parseRepositorySlug(url)).toBe(expected);
+});
+
+test('repositorySlug reads the origin remote', () => {
+  shellRunSpy.mockReturnValue('git@github.com:cdklabs/publib.git');
+  expect(git.repositorySlug()).toBe('cdklabs/publib');
+  expect(shellRunSpy).toHaveBeenCalledWith('git remote get-url origin', { capture: true });
+});
+
+test('repositorySlug returns undefined outside a git repository', () => {
+  shellRunSpy.mockImplementation(() => {
+    throw new Error('fatal: not a git repository');
+  });
+  expect(git.repositorySlug()).toBeUndefined();
+});
+
+test('head returns the current commit hash', () => {
+  shellRunSpy.mockReturnValue('abc123');
+  expect(git.head()).toBe('abc123');
+  expect(shellRunSpy).toHaveBeenCalledWith('git rev-parse HEAD', { capture: true });
+});
+
+test('head returns undefined outside a git repository', () => {
+  shellRunSpy.mockImplementation(() => {
+    throw new Error('fatal: not a git repository');
+  });
+  expect(git.head()).toBeUndefined();
+});

--- a/test/targets/github.test.ts
+++ b/test/targets/github.test.ts
@@ -1,0 +1,134 @@
+import { createGitHubRelease } from '../../src/targets/github';
+
+const originalFetch = global.fetch;
+let mockFetch: jest.Mock;
+
+beforeEach(() => {
+  mockFetch = jest.fn();
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+function respondWith(status: number, body: unknown, statusText = '') {
+  mockFetch.mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  });
+}
+
+const baseOptions = {
+  tag: 'v1.2.3',
+  repository: 'cdklabs/publib',
+  token: 'my-token',
+};
+
+test('creates a release', async () => {
+  respondWith(201, { id: 1 });
+
+  const result = await createGitHubRelease({
+    ...baseOptions,
+    body: '## Changelog',
+    target: 'abcdef123',
+  });
+
+  expect(result).toBe('created');
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const [url, request] = mockFetch.mock.calls[0];
+  expect(url).toBe('https://api.github.com/repos/cdklabs/publib/releases');
+  expect(request.method).toBe('POST');
+  expect(request.headers.Authorization).toBe('Bearer my-token');
+  expect(JSON.parse(request.body)).toEqual({
+    tag_name: 'v1.2.3',
+    name: 'v1.2.3',
+    body: '## Changelog',
+    prerelease: false,
+    target_commitish: 'abcdef123',
+  });
+});
+
+test('marks the release as prerelease', async () => {
+  respondWith(201, { id: 1 });
+
+  await createGitHubRelease({ ...baseOptions, prerelease: true });
+
+  const [, request] = mockFetch.mock.calls[0];
+  expect(JSON.parse(request.body).prerelease).toBe(true);
+});
+
+test('omits target_commitish when no target is given', async () => {
+  respondWith(201, { id: 1 });
+
+  await createGitHubRelease(baseOptions);
+
+  const [, request] = mockFetch.mock.calls[0];
+  expect(JSON.parse(request.body)).not.toHaveProperty('target_commitish');
+});
+
+test('sends make_latest when latest is specified', async () => {
+  respondWith(201, { id: 1 });
+
+  await createGitHubRelease({ ...baseOptions, latest: false });
+
+  const [, request] = mockFetch.mock.calls[0];
+  expect(JSON.parse(request.body).make_latest).toBe('false');
+});
+
+test('omits make_latest when latest is not specified', async () => {
+  respondWith(201, { id: 1 });
+
+  await createGitHubRelease(baseOptions);
+
+  const [, request] = mockFetch.mock.calls[0];
+  expect(JSON.parse(request.body)).not.toHaveProperty('make_latest');
+});
+
+test('tolerates an already existing release', async () => {
+  respondWith(422, {
+    message: 'Validation Failed',
+    errors: [{ resource: 'Release', code: 'already_exists', field: 'tag_name' }],
+  });
+
+  const result = await createGitHubRelease(baseOptions);
+
+  expect(result).toBe('already_exists');
+});
+
+test('fails on other validation errors', async () => {
+  respondWith(422, {
+    message: 'Validation Failed',
+    errors: [{ resource: 'Release', code: 'invalid', field: 'target_commitish' }],
+  }, 'Unprocessable Entity');
+
+  await expect(createGitHubRelease(baseOptions)).rejects.toThrow(/HTTP 422/);
+});
+
+test('fails on other errors with status and body in the message', async () => {
+  respondWith(404, { message: 'Not Found' }, 'Not Found');
+
+  await expect(createGitHubRelease(baseOptions)).rejects.toThrow(
+    /HTTP 404 Not Found: .*Not Found/,
+  );
+});
+
+test('fails on non-JSON error responses', async () => {
+  respondWith(500, 'internal error', 'Internal Server Error');
+
+  await expect(createGitHubRelease(baseOptions)).rejects.toThrow(/HTTP 500/);
+});
+
+test('uses a custom API URL for GitHub Enterprise', async () => {
+  respondWith(201, { id: 1 });
+
+  await createGitHubRelease({
+    ...baseOptions,
+    apiUrl: 'https://github.corporate-enterprise.com/api/v3/',
+  });
+
+  const [url] = mockFetch.mock.calls[0];
+  expect(url).toBe('https://github.corporate-enterprise.com/api/v3/repos/cdklabs/publib/releases');
+});


### PR DESCRIPTION
You can now publish GitHub Releases with publib. The new `publib-github` command creates a GitHub release for a tag, with release notes from a changelog file. Like all other publishers it is driven by environment variables and supports `PUBLIB_DRYRUN`:

```shell
GITHUB_TOKEN=*** \
GITHUB_RELEASE_TAG_FILE=dist/releasetag.txt \
GITHUB_CHANGELOG_FILE=dist/changelog.md \
npx publib-github
```

The target repository and commit are inferred from the local git repository (the `origin` remote and the current `HEAD`), or can be set explicitly via `GITHUB_REPOSITORY` and `GITHUB_SHA` — in GitHub Actions workflows these are already set automatically.

Re-running a release is safe: if a release for the tag already exists, the command succeeds and leaves the existing release untouched. Set `GITHUB_PRERELEASE=true` to mark the release as a prerelease, and `GITHUB_MARK_LATEST=true|false` to control whether GitHub labels it as the latest release — useful when publishing patches for older major versions. GitHub Enterprise instances are supported via `GITHUB_API_URL`.
